### PR TITLE
fix error message

### DIFF
--- a/editor_plugin/Dashboard.gd
+++ b/editor_plugin/Dashboard.gd
@@ -1,6 +1,6 @@
 @tool
-extends MarginContainer
 class_name JamEditorPluginDashboard
+extends MarginContainer
 
 var msg_scn = preload("res://addons/jam_launch/ui/MessagePanel.tscn")
 var plugin: EditorPlugin

--- a/editor_plugin/JamEditorPluginPage.gd
+++ b/editor_plugin/JamEditorPluginPage.gd
@@ -1,6 +1,6 @@
 @tool
-extends Control
 class_name JamEditorPluginPage
+extends Control
 
 var dashboard: JamEditorPluginDashboard
 var project_api: JamProjectApi


### PR DESCRIPTION
Fixed error message about JamEditorPluginDashboard not found.

the class name should be set and then we extend it. Not the opposite :)